### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+## Cursor Cloud specific instructions
+
+This is a Go library (`github.com/zhangbaodong/test`) providing greeting functionality. No external dependencies; uses only the Go standard library.
+
+### Known build issue
+
+`say.go` and `say_optimized.go` both declare `SayHi` in `package test` without build tags. Running `go test ./...` or `go build ./...` at the package level **will fail** with a redeclaration error. Use explicit file lists as `build.sh` does:
+
+```bash
+# Run benchmarks with the optimized implementation
+go test -v -bench=. -benchmem ./say_test.go ./say_optimized.go
+
+# Run benchmarks with the original implementation
+go test -v -bench=. -benchmem ./say_test.go ./say.go
+```
+
+The `examples/` programs import the package and therefore also fail to compile via `go run`. Use the pre-compiled binaries (`test-app`, `test-app-optimized`) to run the web server on port 8080.
+
+### Running the web server
+
+```bash
+./test-app          # starts on :8080
+# or
+./test-app-optimized  # optimized build, also :8080
+```
+
+Endpoints: `/` (HTML form), `/greet?name=X`, `/api/greet?name=X` (JSON), `/api/simple?name=X` (plain text).
+
+### Building optimized binaries
+
+Run `bash build.sh` — it builds into `bin/` and runs benchmarks.


### PR DESCRIPTION
Add `AGENTS.md` to document development environment setup and known issues.

The `say.go` and `say_optimized.go` files both define `SayHi` in the same package without build tags, preventing standard `go test ./...` and `go run examples/...` commands. `AGENTS.md` explains this issue and the workaround of explicitly specifying files, as used in `build.sh`.

---
<p><a href="https://cursor.com/agents/bc-039a71b7-92a3-45fc-8ba5-0b2bb08bef66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-039a71b7-92a3-45fc-8ba5-0b2bb08bef66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

